### PR TITLE
Take Image exposed port into consideration

### DIFF
--- a/internal/targetproviders/docker/container.go
+++ b/internal/targetproviders/docker/container.go
@@ -78,6 +78,10 @@ func (c *container) setContainerPorts(dcontainer ctypes.InspectResponse, dservic
 	c.log.Trace().Msg("start setContainerPorts")
 	defer c.log.Trace().Msg("end setContainerPorts")
 
+	for p, _ := range dcontainer.Config.ExposedPorts {
+		c.ports[p.Port()] = ""
+	}
+
 	if c.networkMode.IsHost() {
 		for p := range dcontainer.HostConfig.PortBindings {
 			c.ports[p.Port()] = p.Port()


### PR DESCRIPTION
When tsdproxy can talk to internal ports of the container, there is no need to publish the port to host machine.